### PR TITLE
Update Roto docs for Rotonda 0.3

### DIFF
--- a/manual/source/_ext/roto_domain.py
+++ b/manual/source/_ext/roto_domain.py
@@ -90,7 +90,10 @@ class RotoType(ObjectDescription):
         signode += addnodes.desc_annotation(text="type")
         signode += addnodes.desc_name(text=sig)
         return sig
-
+    
+    def _toc_entry_name(self, signode):
+        text = signode.children[1].children[0]
+        return str(text)
     
     def add_target_and_index(self, name_cls, sig, signode):
         signode['ids'].append('roto' + '-' + sig)

--- a/manual/source/roto/00_introduction.rst
+++ b/manual/source/roto/00_introduction.rst
@@ -7,12 +7,10 @@ in Roto:
 .. code-block:: roto
 
     filter disallow_ip(message: BgpMessage) {
-        apply {
-            if message.ip() == 0.0.0.0 {
-                reject
-            } else {
-                accept message
-            }
+        if message.ip() == 0.0.0.0 {
+            reject
+        } else {
+            accept message
         }
     }
 

--- a/manual/source/roto/01_reference.rst
+++ b/manual/source/roto/01_reference.rst
@@ -8,7 +8,7 @@ the language.
 Comments
 --------
 
-Comments in Roto start with a ``#`` and end at the end of a line. They can
+Comments in Roto start with a ``#`` and continue until the end of a line. They can
 be inserted anywhere in the script and are ignored.
 
 .. code-block:: roto
@@ -200,8 +200,8 @@ Strings can be concatenated with ``+``:
 
     "race" + "car" # yields the string "racecar"
 
-It also has some methods such as :ref:`String.contains` that can be very
-useful. See the documentation for the :ref:`String` type for more
+It also has some methods such as :roto:ref:`String.contains` that can be very
+useful. See the documentation for the :roto:ref:`String` type for more
 information.
 
 If-else

--- a/manual/source/roto/01_reference.rst
+++ b/manual/source/roto/01_reference.rst
@@ -34,9 +34,12 @@ Roto supports literals for primitive types:
   for IP addresses
 - ``0.0.0.0/10`` for prefixes
 - ``AS1234`` for AS numbers
+- ``"Hello"`` for strings
 
 Primitive types
 ---------------
+
+There are several types at Roto's core, which can be expressed as literals.
 
 - :roto:ref:`bool`: booleans
 - :roto:ref:`u8`, :roto:ref:`u16`, :roto:ref:`u32`, :roto:ref:`u64`: unsigned integers of 8, 16, 32 and 64 bits, respectively
@@ -44,9 +47,11 @@ Primitive types
 - :roto:ref:`IpAddr`: IP address
 - :roto:ref:`Prefix`: prefixes
 - :roto:ref:`Asn`: AS number
+- :roto:ref:`String`: Strings
 
 There are many more types available that have more to do with BGP. These are
-described elsewhere.
+described elsewhere. Note that Roto is case sensitive; writing the ``Asn`` type as
+``ASN`` or ``asn`` won't work.
 
 Integers
 --------
@@ -180,6 +185,25 @@ This is equivalent to:
 
     ((1 + (x * 3)) == 5) && (y < 10)
 
+Strings
+-------
+
+Strings are enclosed in double quotes like so:
+
+.. code-block:: roto
+
+    "This is a string!"
+
+Strings can be concatenated with ``+``:
+
+.. code-block:: roto
+
+    "race" + "car" # yields the string "racecar"
+
+It also has some methods such as :ref:`String.contains` that can be very
+useful. See the documentation for the :ref:`String` type for more
+information.
+
 If-else
 -------
 
@@ -257,6 +281,16 @@ This function does not return anything:
 The ``return`` keyword can still be used in functions that don't return a value to
 exit the function early.
 
+When a function becomes more complex, intermediate results can be stored in local
+variables with ``let``.
+
+.. code-block:: roto
+
+    function greater_than_square(x: i32, y: i32) {
+        let y_squared = y * y;
+        x > y_squared
+    }
+
 Filter-map
 ----------
 
@@ -264,40 +298,33 @@ A ``filter-map`` is a function that filters and transforms some incoming value.
 
 Filter-maps resemble functions but they don't ``return``. Instead they
 either ``accept`` or ``reject``, which determines what happens to the value.
-
-A very simple ``filter-map`` takes just one parameter and only has an ``apply``
-section:
+Generally, as accepted value is stored or fed to some other component and a
+reject value is dropped.
 
 .. code-block:: roto
 
     filter-map reject_zeros(input: IpAddr) {
-        apply {
-            if input == 0.0.0.0 {
-                reject
-            } else {
-                accept
-            }
+        if input == 0.0.0.0 {
+            reject
+        } else {
+            accept
         }
     }
 
 This describes a filter which takes in an IP address and accepts it if it is not
 equal to ``0.0.0.0``.
 
-A more complicated filter can use a ``define`` section to add variable
-definitions.
+Like with functions, intermediate results can be stored in variables with let
+bindings.
 
 .. code-block:: roto
 
     filter-map reject_zeros(input: IpAddr) {
-        define {
-            zeros = 0.0.0.0;
-        }
-        apply {
-            if input == zeros {
-                reject
-            } else {
-                accept
-            }
+        let zeros = 0.0.0.0;
+        if input == zeros {
+            reject
+        } else {
+            accept
         }
     }
 
@@ -368,3 +395,8 @@ There is an automatic coercion from anonymous records to named records:
         { foo: int, bar: false }  # implicitly coerced to SomeRecord
     }
 
+Next steps
+----------
+
+You can learn more about Roto by looking at the documentation for the
+:doc:`02_rotonda_std`.

--- a/manual/source/roto/02_rotonda_std.md
+++ b/manual/source/roto/02_rotonda_std.md
@@ -1,5 +1,35 @@
 # Standard Library
 
+````{roto:function} Community(raw: u32) -> Community
+````
+
+`````{roto:context} output: Log
+`````
+
+`````{roto:constant} LOCALHOSTV6: IpAddr
+The IPv6 address pointing to localhost: `::1`
+`````
+
+`````{roto:constant} NO_ADVERTISE: Community
+The well-known NO_ADVERTISE community (RFC1997)
+`````
+
+`````{roto:constant} LOCALHOSTV4: IpAddr
+The IPv4 address pointing to localhost: `127.0.0.1`
+`````
+
+`````{roto:constant} NO_EXPORT: Community
+The well-known NO_EXPORT community (RFC1997)
+`````
+
+`````{roto:constant} NO_EXPORT_SUBCONFED: Community
+The well-known NO_EXPORT_SUBCONFED community (RFC1997)
+`````
+
+`````{roto:constant} NO_PEER: Community
+The well-known NO_PEER community (RFC3765)
+`````
+
 `````{roto:type} Unit
 The unit type that has just one possible value. It can be used when there is nothing meaningful to be returned.
 
@@ -71,6 +101,18 @@ This type can represent integers from -9223372036854775808 up to (and including)
 `````{roto:type} Asn
 An ASN: an Autonomous System Number
 
+An AS number can contain a number of 32-bits and is therefore similar to a [`u32`](u32). However, AS numbers cannot be manipulated with arithmetic operations. An AS number is constructed with the `AS` prefix followed by a number.
+
+```roto
+AS0
+AS1010
+AS4294967295
+```
+
+````{roto:method} Asn.fmt() -> String
+Return the formatted string for `asn`
+````
+
 `````
 
 `````{roto:type} IpAddr
@@ -134,10 +176,11 @@ Converts this address to an IPv4 if it is an IPv4-mapped IPv6 address, otherwise
 `````
 
 `````{roto:type} Prefix
-An IP address prefix: an IP address and a prefix length
+An IP address prefix: the combination of an IP address and a prefix length
 
-A prefix can be constructed with the `/` operator or with the `Prefix.new` function.
+A prefix can be constructed with the `/` operator or with the [`Prefix.new`](Prefix.new) function. This operator takes an [`IpAddr`](IpAddr) and a [`u8`](u8) as operands.
 
+            
 ```roto
 1.1.1.0 / 8
 192.0.0.0.0 / 24
@@ -146,10 +189,77 @@ A prefix can be constructed with the `/` operator or with the `Prefix.new` funct
 ````{roto:static_method} Prefix.new(ip: IpAddr, len: u8) -> Prefix
 Construct a new prefix
 
-A prefix can also be constructed with a prefix literal.
+A prefix can also be constructed with the `/` operator.
 
 ```roto
-Prefix.new(192.169.0.0)
+Prefix.new(192.169.0.0, 16)
+
+# or equivalently
+192.169.0.0 / 16
+```
+````
+
+`````
+
+`````{roto:type} String
+The string type
+
+````{roto:method} String.append(b: String) -> String
+Append a string to another, creating a new string
+
+```roto
+"hello".append(" ").append("world") # -> "hello world"
+```
+````
+
+````{roto:method} String.contains(needle: String) -> bool
+Check whether a string contains another string
+
+```roto
+"haystack".contains("hay")  # -> true
+"haystack".contains("corn") # -> false
+```
+````
+
+````{roto:method} String.starts_with(prefix: String) -> bool
+Check whether a string starts with a given prefix
+
+```roto
+"haystack".contains("hay")   # -> true
+"haystack".contains("trees") # -> false
+```
+````
+
+````{roto:method} String.ends_with(suffix: String) -> bool
+Check whether a string end with a given suffix
+
+```roto
+"haystack".contains("stack") # -> true
+"haystack".contains("black") # -> false
+```
+````
+
+````{roto:method} String.to_lowercase() -> String
+Create a new string with all characters converted to lowercase
+
+```roto
+"LOUD".to_lowercase() # -> "loud"
+```
+````
+
+````{roto:method} String.to_uppercase() -> String
+Create a new string with all characters converted to lowercase
+
+```roto
+"quiet".to_uppercase() # -> "QUIET"
+```
+````
+
+````{roto:method} String.repeat(n: u32) -> String
+Repeat a string `n` times and join them
+
+```roto
+"ha".repeat(6) # -> "hahahahahaha"
 ```
 ````
 
@@ -159,12 +269,43 @@ Prefix.new(192.169.0.0)
 A single announced or withdrawn path
 
 ````{roto:method} Route.prefix_matches(to_match: Prefix) -> bool
+Check whether the prefix for this `RotondaRoute` matches
 ````
 
-````{roto:method} Route.aspath_origin(to_match: Asn) -> bool
+````{roto:method} Route.aspath_contains(to_match: Asn) -> bool
+Check whether the AS_PATH contains the given `Asn`
+````
+
+````{roto:method} Route.match_aspath_origin(to_match: Asn) -> bool
+Check whether the AS_PATH origin matches the given `Asn`
+````
+
+````{roto:method} Route.contains_community(to_match: Community) -> bool
+Check whether this `RotondaRoute` contains the given Standard Community
+````
+
+````{roto:method} Route.contains_large_community(to_match: LargeCommunity) -> bool
+Check whether this `RotondaRoute` contains the given Large Community
 ````
 
 ````{roto:method} Route.has_attribute(to_match: u8) -> bool
+Check whether this `RotondaRoute` contains the given Path Attribute
+````
+
+````{roto:method} Route.fmt_aspath() -> String
+Return a formatted string for the AS_PATH
+````
+
+````{roto:method} Route.fmt_aspath_origin() -> String
+Return a formatted string for the AS_PATH origin
+````
+
+````{roto:method} Route.fmt_communities() -> String
+Return a formatted string for the Standard Communities
+````
+
+````{roto:method} Route.fmt_large_communities() -> String
+Return a formatted string for the Large Communities
 ````
 
 `````
@@ -177,27 +318,56 @@ Contextual information pertaining to the Route
 `````{roto:type} Provenance
 Session/state information
 
+````{roto:method} Provenance.peer_asn() -> Asn
+Return the peer ASN
+````
+
 `````
 
 `````{roto:type} Log
 Machinery to create output entries
 
 ````{roto:method} Log.log_prefix(prefix: Prefix) -> Unit
+Log the given prefix (NB: this method will likely be removed)
 ````
 
 ````{roto:method} Log.log_matched_asn(asn: Asn) -> Unit
+Log the given ASN (NB: this method will likely be removed)
 ````
 
 ````{roto:method} Log.log_matched_origin(origin: Asn) -> Unit
+Log the given ASN as origin (NB: this method will likely be removed)
 ````
 
 ````{roto:method} Log.log_matched_community(community: u32) -> Unit
+Log the given community (NB: this method will likely be removed)
 ````
 
 ````{roto:method} Log.log_peer_down() -> Unit
+Log a PeerDown event
 ````
 
 ````{roto:method} Log.log_custom(id: u32, local: u32) -> Unit
+Log a custom entry in forms of a tuple (NB: this method will likely be removed)
+````
+
+````{roto:method} Log.print(msg: String) -> Unit
+Print a message to standard error
+````
+
+````{roto:method} Log.entry() -> LogEntryPtr
+Get the current/new entry
+
+A `LogEntry` is only written to the output if [`write_entry`] is
+called on it after populating its fields.
+````
+
+````{roto:method} Log.write_entry() -> Unit
+Finalize this entry and ensure it will be written to the output
+
+Calling this method will close the log entry that is currently being
+composed, and ensures a subsequent call to [`entry`] returns a new,
+empty `LogEntry`.
 ````
 
 `````
@@ -205,10 +375,54 @@ Machinery to create output entries
 `````{roto:type} InsertionInfo
 Information from the RIB on an inserted route
 
-````{roto:method} InsertionInfo.new_peer() -> bool
+`````
+
+`````{roto:type} LogEntry
+Entry to log to file/mqtt
+
+`````
+
+`````{roto:type} LogEntryPtr
+Entry to log to file/mqtt
+
+````{roto:method} LogEntryPtr.custom(custom_msg: String) -> Unit
+Log a custom message based on the given string
+
+By setting a custom message for a `LogEntry`, all other fields are
+ignored when the entry is written to the output. Combining the custom
+message with the built-in fields is currently not possible.
 ````
 
-````{roto:method} InsertionInfo.prefix_new() -> bool
+````{roto:method} LogEntryPtr.origin_as(msg: BmpMsg) -> LogEntryPtr
+Log the AS_PATH origin ASN for the given message
+````
+
+````{roto:method} LogEntryPtr.peer_as(msg: BmpMsg) -> LogEntryPtr
+Log the peer ASN for the given message
+````
+
+````{roto:method} LogEntryPtr.as_path_hops(msg: BmpMsg) -> LogEntryPtr
+Log the number of AS_PATH hops for the given message
+````
+
+````{roto:method} LogEntryPtr.conventional_reach(msg: BmpMsg) -> LogEntryPtr
+Log the number of conventional announcements for the given message
+````
+
+````{roto:method} LogEntryPtr.conventional_unreach(msg: BmpMsg) -> LogEntryPtr
+Log the number of conventional withdrawals for the given message
+````
+
+````{roto:method} LogEntryPtr.mp_reach(msg: BmpMsg) -> LogEntryPtr
+Log the number of MultiProtocol announcements for the given message
+````
+
+````{roto:method} LogEntryPtr.mp_unreach(msg: BmpMsg) -> LogEntryPtr
+Log the number of MultiProtocol withdrawals for the given message
+````
+
+````{roto:method} LogEntryPtr.log_all(msg: BmpMsg) -> LogEntryPtr
+Log all the built-in features for the given message
 ````
 
 `````
@@ -217,16 +431,62 @@ Information from the RIB on an inserted route
 BGP UPDATE message
 
 ````{roto:method} BgpMsg.aspath_contains(to_match: Asn) -> bool
+Check whether the AS_PATH contains the given `Asn`
 ````
 
-````{roto:method} BgpMsg.aspath_origin(to_match: Asn) -> bool
+````{roto:method} BgpMsg.match_aspath_origin(to_match: Asn) -> bool
+Check whether the AS_PATH origin matches the given `Asn`
 ````
 
-````{roto:method} BgpMsg.contains_community(to_match: u32) -> bool
+````{roto:method} BgpMsg.contains_community(to_match: Community) -> bool
+Check whether this message contains the given Standard Community
+````
+
+````{roto:method} BgpMsg.contains_large_community(to_match: LargeCommunity) -> bool
+Check whether this message contains the given Large Community
 ````
 
 ````{roto:method} BgpMsg.has_attribute(to_match: u8) -> bool
+Check whether this message contains the given Path Attribute
 ````
+
+````{roto:method} BgpMsg.announcements_count() -> u32
+Return the number of announcements in this message
+````
+
+````{roto:method} BgpMsg.withdrawals_count() -> u32
+Return the number of withdrawals in this message
+````
+
+````{roto:method} BgpMsg.fmt_aspath() -> String
+Return a formatted string for the AS_PATH
+````
+
+````{roto:method} BgpMsg.fmt_aspath_origin() -> String
+Return a formatted string for the AS_PATH origin
+````
+
+````{roto:method} BgpMsg.fmt_communities() -> String
+Return a formatted string for the Standard Communities
+````
+
+````{roto:method} BgpMsg.fmt_large_communities() -> String
+Return a formatted string for the Large Communities
+````
+
+````{roto:method} BgpMsg.fmt_pcap() -> String
+Format this message as hexadecimal Wireshark input
+````
+
+`````
+
+`````{roto:type} Community
+A BGP Standard Community (RFC1997)
+
+`````
+
+`````{roto:type} LargeCommunity
+A BGP Large Community (RFC8092)
 
 `````
 
@@ -234,21 +494,66 @@ BGP UPDATE message
 BMP Message
 
 ````{roto:method} BmpMsg.is_ibgp(asn: Asn) -> bool
+Check whether this is an iBGP message based on a given `asn`
+
+Return true if `asn` matches the asn in the `BmpMsg`.
+returns false if no PPH is present.
+````
+
+````{roto:method} BmpMsg.is_route_monitoring() -> bool
+Check whether this message is of type 'RouteMonitoring'
 ````
 
 ````{roto:method} BmpMsg.is_peer_down() -> bool
+Check whether this message is of type 'PeerDownNotification'
 ````
 
 ````{roto:method} BmpMsg.aspath_contains(to_match: Asn) -> bool
+Check whether the AS_PATH contains the given `Asn`
 ````
 
-````{roto:method} BmpMsg.aspath_origin(to_match: Asn) -> bool
+````{roto:method} BmpMsg.match_aspath_origin(to_match: Asn) -> bool
+Check whether the AS_PATH origin matches the given `Asn`
 ````
 
-````{roto:method} BmpMsg.contains_community(to_match: u32) -> bool
+````{roto:method} BmpMsg.contains_community(to_match: Community) -> bool
+Check whether this message contains the given Standard Community
+````
+
+````{roto:method} BmpMsg.contains_large_community(to_match: LargeCommunity) -> bool
+Check whether this message contains the given Large Community
 ````
 
 ````{roto:method} BmpMsg.has_attribute(to_match: u8) -> bool
+Check whether this message contains the given Path Attribute
+````
+
+````{roto:method} BmpMsg.announcements_count() -> u32
+Return the number of announcements in this message
+````
+
+````{roto:method} BmpMsg.withdrawals_count() -> u32
+Return the number of withdrawals in this message
+````
+
+````{roto:method} BmpMsg.fmt_aspath() -> String
+Return a formatted string for the AS_PATH
+````
+
+````{roto:method} BmpMsg.fmt_aspath_origin() -> String
+Return a string of the AS_PATH origin for this `BmpMsg`.
+````
+
+````{roto:method} BmpMsg.fmt_communities() -> String
+Return a string for the Standard Communities in this `BmpMsg`.
+````
+
+````{roto:method} BmpMsg.fmt_large_communities() -> String
+Return a string for the Large Communities in this `BmpMsg`.
+````
+
+````{roto:method} BmpMsg.fmt_pcap() -> String
+Format this message as hexadecimal Wireshark input
 ````
 
 `````


### PR DESCRIPTION
Includes:
- Strings
- Some rephrasing
- Table of content entries for Roto types
- Changing `define/apply` to `let`